### PR TITLE
making xslate spit out warning and die https://github.com/genehack/Hi…

### DIFF
--- a/lib/HiD/Processor/IIBlog.pm
+++ b/lib/HiD/Processor/IIBlog.pm
@@ -50,7 +50,12 @@ sub BUILDARGS {
         lc          => sub { lc( shift ) } ,
         pretty_date => sub { shift->strftime( "%d %b %Y" ) },
       } ,
-      path => $path ,
+      path => $path,
+      warn_handler => sub {
+        my $self = shift;
+        say($self);
+        die;
+      }
     ),
   };
 }


### PR DESCRIPTION
This change should override the default xslate warn handler to still say the error but also die.